### PR TITLE
Added logic to pause menu

### DIFF
--- a/main/level_1.gd
+++ b/main/level_1.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _ready():
+	pass

--- a/main/level_1.tscn
+++ b/main/level_1.tscn
@@ -1,17 +1,19 @@
-[gd_scene load_steps=2 format=3 uid="uid://drbut2arpvesd"]
+[gd_scene load_steps=4 format=3 uid="uid://drbut2arpvesd"]
 
+[ext_resource type="Script" path="res://main/level_1.gd" id="1_d3jfb"]
 [ext_resource type="PackedScene" uid="uid://ey7qekfsbkai" path="res://player/Player.tscn" id="1_lqipx"]
+[ext_resource type="PackedScene" uid="uid://xltm3j142qwi" path="res://menus/pause_menu.tscn" id="3_sns4i"]
 
-[node name="World" type="Node2D"]
-
-[node name="Label" type="Label" parent="."]
-offset_left = 333.0
-offset_top = 2.0
-offset_right = 722.0
-offset_bottom = 117.0
-text = "New World"
-horizontal_alignment = 1
-vertical_alignment = 1
+[node name="level1" type="Node2D"]
+process_mode = 1
+script = ExtResource("1_d3jfb")
 
 [node name="Player" parent="." instance=ExtResource("1_lqipx")]
 position = Vector2(346, 255)
+
+[node name="PauseMenu" parent="." instance=ExtResource("3_sns4i")]
+process_mode = 3
+offset_left = 586.0
+offset_top = 326.0
+offset_right = 586.0
+offset_bottom = 326.0

--- a/menus/pause_menu.gd
+++ b/menus/pause_menu.gd
@@ -21,4 +21,5 @@ func _on_resume_button_pressed():
 	game_paused = false
 
 func _on_quit_button_pressed():
+	game_paused = false
 	get_tree().change_scene_to_file("res://menus/menu.tscn")

--- a/menus/pause_menu.gd
+++ b/menus/pause_menu.gd
@@ -1,28 +1,24 @@
 extends Control
 
-var game_paused : bool = false:
-	get:
-		return game_paused
-	set(value):
-		game_paused = value
-		get_tree().paused = game_paused
-		_update_visibility()
+var game_paused : bool = false : get = _get_game_paused, set = _set_game_paused
 
 func _ready():
 	hide()
+
+func _get_game_paused():
+	return game_paused
+	
+func _set_game_paused(new_state: bool):
+	game_paused = new_state
+	get_tree().paused = game_paused
+	show() if game_paused else hide()
 
 func _input(event : InputEvent):
 	if(event.is_action_pressed("ui_cancel")):
 		game_paused = !game_paused
 
-func _update_visibility():
-	if game_paused:
-		show()
-	else:
-		hide()
-
-func _on_quit_button_pressed():
-	get_tree().quit()
-
 func _on_resume_button_pressed():
 	game_paused = false
+
+func _on_quit_button_pressed():
+	get_tree().change_scene_to_file("res://menus/menu.tscn")

--- a/menus/pause_menu.gd
+++ b/menus/pause_menu.gd
@@ -1,11 +1,28 @@
 extends Control
 
+var game_paused : bool = false:
+	get:
+		return game_paused
+	set(value):
+		game_paused = value
+		get_tree().paused = game_paused
+		_update_visibility()
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	hide()
 
+func _input(event : InputEvent):
+	if(event.is_action_pressed("ui_cancel")):
+		game_paused = !game_paused
+
+func _update_visibility():
+	if game_paused:
+		show()
+	else:
+		hide()
 
 func _on_quit_button_pressed():
-	pass
-	
+	get_tree().quit()
+
+func _on_resume_button_pressed():
+	game_paused = false

--- a/menus/pause_menu.tscn
+++ b/menus/pause_menu.tscn
@@ -19,10 +19,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -127.0
-offset_top = -160.0
-offset_right = 123.0
-offset_bottom = 158.0
+offset_left = -97.0
+offset_top = -72.0
+offset_right = 153.0
+offset_bottom = 33.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -31,6 +31,8 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_top = 5.0
+offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -47,4 +49,5 @@ text = "Resume"
 layout_mode = 2
 text = "Quit"
 
+[connection signal="pressed" from="Panel/VBoxContainer/resumeButton" to="." method="_on_resume_button_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/quitButton" to="." method="_on_quit_button_pressed"]


### PR DESCRIPTION
### Description

**Describe the purpose of this pull request.**

<!-- Provide a brief summary of the changes and why they are being made. -->

Added the pause menu and its logic to the level scene.

### Image/Video


https://github.com/FlamingoFiestaStudio/OlympusGoneWild/assets/116306408/f92dec20-50c7-485f-94c8-fa12a76077b6


### Related Issue

**Closes #ISSUE_NUMBER**

### Does this PR introduce a breaking change? ⚠️

- [x] No
- [ ] Yes <!-- ::WARNING:: If your PR has a breaking change, your commit body message MUST include "BREAKING CHANGE"   -->
<!-- If this PR contains a breaking change, please describe the impact. -->

### Tests

- [x] I tested all game E2E;
- [ ] I just tested some scenes;
- [ ] Not applicable.

### Check list

Before submitting this pull request, please ensure the following are completed:

- [x] [My commits follow the project conventions](https://gist.github.com/tonibardina/9290fbc7d605b4f86919426e614fe692).
- [x] My code follows the project's coding style and conventions.
- [ ] I have updated the project documentation (if necessary).
- [x] My code makes sense with the design.

## Additional Notes

<!-- Any additional information or context that might be helpful for the reviewers. -->

---

Thank you for your contribution to Olympus Gone Wild! Your effort is greatly appreciated, and it helps make this project better for everyone. 😄🎮🚀
