### PR TITLE
Add documentation to report a security breach

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
@@ -2,7 +2,7 @@
 name: Security Vulnerability Report
 about: You found a security break in the project (not a bug in the final game)
 title: 'SECURITY VULNERABILITY: '
-labels: "P1 \U0001F525, programming, Refinement"
+labels: "P1 \U0001F525, programming, Refinement, SECURITY"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
@@ -1,0 +1,54 @@
+---
+name: Security Vulnerability Report
+about: You found a security break in the project (not a bug in the final game)
+title: 'SECURITY VULNERABILITY: '
+labels: "P1 \U0001F525, programming, Refinement"
+assignees: ''
+
+---
+
+<!-- IMPORTANT: This report is intended for security-related issues only. Please use our others issue templates for non-security-related matters. -->
+
+<!-- Write "N/A." If it's not applicable, and "Not tested." if you didn't test -->
+
+### Security Vulnerability Report
+
+- **Version:** [Specify the version, if applicable]
+- **Severity:** [Low / Moderate / High / Critical]
+
+**Vulnerability Description:**
+
+<!-- Provide a brief and clear description of the security vulnerability. -->
+
+**Steps to Reproduce:**
+
+1. [Detail the steps or conditions required to reproduce the vulnerability.]
+2. [Include any relevant code, configurations, or examples.]
+
+**Impact:**
+
+<!-- Explain the potential impact and consequences of the vulnerability. -->
+
+**Proposed Fix:**
+
+<!-- If you have a suggestion for a fix or mitigation, provide it here. -->
+
+**Additional Information:**
+
+<!-- Include any additional information, links, or references that may be helpful in understanding the issue. -->
+
+**Confidentiality Notice:**
+
+By reporting this security vulnerability, you acknowledge that the report may be subject to responsible disclosure guidelines and that you will not disclose the details of the vulnerability until it has been resolved.
+
+**Contact Information:**
+
+Please provide a reliable and secure contact method to facilitate further communication regarding this report.
+
+
+**Dev notes**
+
+<!-- Pls  do not fill this, our team will write here all the updates that happen regarding this ticket -->
+
+
+<!-- Thank you for contributing to the security of our project! :) -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Olympus Gone Wild Security Policy
+
+## Reporting a Security Vulnerability
+
+At Olympus Gone Wild, we take security seriously and value the contributions of security researchers and the community to help us maintain a secure project. If you discover a security vulnerability, we encourage you to report it to us as soon as possible. We will investigate all legitimate reports and do our best to quickly fix the issue.
+
+To report a security vulnerability, please follow these steps:
+
+1. **Create a New Issue**: Go to the [Issues](https://github.com/FlamingoFiestaStudio/OlympusGoneWild/issues) tab of our GitHub repository and click "New Issue";
+
+2. **Use the Security Vulnerability Template**: To ensure the proper evaluation of the issue, use the provided "Security Vulnerability Report" template when creating the issue;
+
+3. **Provide Details**: Be sure to provide as much information as possible, including a description of the vulnerability, steps to reproduce it, and any relevant code or configurations;
+
+4. **Keep the Report Confidential**: Please do not disclose the issue publicly until we've had a chance to review and address it. We will strive to maintain open communication during the resolution process;
+
+## Response and Resolution
+
+Once we receive a security vulnerability report, our team will:
+
+- Confirm the issue and determine its severity;
+- Prioritize the issue and assign it to an appropriate member of our team;
+- Work to develop and test a fix;
+- Communicate with the reporter regarding the issue's status and, if applicable, coordinate the release of a fix;
+- Our team will keep all updates in the `Dev Notes` section of the reported issue;
+- Publish the fix and provide proper attribution to the reporter, if desired;
+
+## Security Updates
+
+As part of our commitment to security, we will regularly review and update our dependencies and components to address known vulnerabilities. We encourage users to stay up-to-date with our latest releases, which will include security fixes when necessary.
+
+## Responsible Disclosure
+
+We request that security researchers and reporters follow responsible disclosure principles by not disclosing the details of the vulnerability until we have addressed it. We will do our best to acknowledge your efforts and maintain open communication throughout the process.
+
+Thank you for helping to keep Olympus Gone Wild secure!


### PR DESCRIPTION
### Description

- Created a new issue template for a security breach report;
- Create the `SECURITY.md` file;

### Image/Video

N/A.

### Related Issue

**Closes #44**

### Does this PR introduce a breaking change? ⚠️

- [X] No
- [ ] Yes

### Tests

- [ ] I tested all game E2E;
- [ ] I just tested some scenes;
- [X] Not applicable.

### Check list

Before submitting this pull request, please ensure the following are completed:

- [X] [My commits follow the project conventions](https://github.com/FlamingoFiestaStudio/OlympusGoneWild/wiki/ProjectBestPractices#commit-message-convections).
- [ ] My code follows the project's coding style and conventions.
- [X] I have updated the project documentation (if necessary).
- [ ] My code makes sense with the design.

## Additional Notes

This PR seems scary, but, in principle this will never be used, it's just to increase ["Community Standards"](https://github.com/FlamingoFiestaStudio/OlympusGoneWild/community), to have bigger community :)

---

Thank you for your contribution to Olympus Gone Wild! Your effort is greatly appreciated, and it helps make this project better for everyone. 😄🎮🚀
