### PR TITLE
Config scaling behavior

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -14,10 +14,20 @@ config/name="Olympus Gone Wild"
 run/main_scene="res://menus/menu.tscn"
 config/features=PackedStringArray("4.0", "Forward Plus")
 
+[display]
+
+window/size/viewport_width=1280
+window/size/viewport_height=720
+window/stretch/mode="viewport"
+
 [editor]
 
 version_control/plugin_name="GitPlugin"
 version_control/autoload_on_startup=true
+
+[editor_plugins]
+
+enabled=PackedStringArray()
 
 [input]
 


### PR DESCRIPTION
### Description

- Fixed the aspect ratio to 1280×720 (16:9);
- On upscaling or downscaling the window the aspect ratio, will keep the same;

### Image/Video

![Image](https://github.com/FlamingoFiestaStudio/OlympusGoneWild/assets/55815265/9e3b0f36-f26b-4b13-9bbf-466dea9defa5)

### Related Issue

**Closes #99**

### Does this PR introduce a breaking change? ⚠️

- [X] No
- [ ] Yes

### Tests

- [X] I tested all game E2E;
- [ ] I just tested some scenes;
- [ ] Not applicable.

### Check list

Before submitting this pull request, please ensure the following are completed:

- [X] [My commits follow the project conventions](https://github.com/FlamingoFiestaStudio/OlympusGoneWild/wiki/ProjectBestPractices#commit-message-convections).
- [X] My code follows the project's coding style and conventions.
- [ ] I have updated the project documentation (if necessary).
- [ ] My code makes sense with the design.

## Additional Notes

N/A.

---

Thank you for your contribution to Olympus Gone Wild! Your effort is greatly appreciated, and it helps make this project better for everyone. 😄🎮🚀
